### PR TITLE
Proposta pull request - Correção link imagem para Aula 8

### DIFF
--- a/notebooks/Aula_8_pandas_estatistica.ipynb
+++ b/notebooks/Aula_8_pandas_estatistica.ipynb
@@ -309,7 +309,7 @@
     }
    },
    "source": [
-    "<img src=\"images/correlação.png\" alt=\"correlação\" style=\"width: 600px;\"/>\n",
+    "<img src=\"images/correlação.png\" alt=\"correlação\" style=\"width: 600px;\"/>\n",
     "\n",
     "* Primeira Fileira: Exemplos de correlações entre $-1$ e $1$\n",
     "* Segunda Fileira: Correlação não altera a inclinação (*slope*) entre duas variáveis\n",


### PR DESCRIPTION
Professor,

Na 21ª célula do notebook da aula 8, há uma imagem não carregada conforme destacado na imagem abaixo:

![erro](https://user-images.githubusercontent.com/35925620/76693750-47b65980-6649-11ea-8826-60235e4e7bfb.png)

Aparentemente, o código ASCII da string "correlação.png" que estava presente no código não é o mesmo que o nome + extensão do arquivo, embora são sejam visualmente iguais.

**Esta é a string original que não carrega a imagem:** correlação.png
**Esta é a string copiada direto do nome do arquivo:** correlação.png

3 fontes usadas indicaram a mesma diferença:

### 1. Comparação no site http://asciivalue.com/

Retorno do código ASCII da string que estava presente no código:

![image](https://user-images.githubusercontent.com/35925620/76693838-4c2f4200-664a-11ea-83af-acec08ea9ddc.png)

Retorno do código ASCII ao copiar nome da imagem + extensão direto do arquivo da imagem:

![image](https://user-images.githubusercontent.com/35925620/76693854-8993cf80-664a-11ea-9e2b-f5a8633f5031.png)

### 2. Comparação no site https://www.diffchecker.com/

Ao comparar as suas strings, o site aponta diferença conforme imagem abaixo:

![image](https://user-images.githubusercontent.com/35925620/76693911-09219e80-664b-11ea-8ff0-969f0be2c19a.png)

### 3. O próprio git:

Após commit, o git apontou a mesma diferença conforme imagem abaixo:

![Screenshot_2](https://user-images.githubusercontent.com/35925620/76693935-3706e300-664b-11ea-85a9-1ee97a045543.png)

Ao retestar a visualização da 21ª célula após alteração, a imagem **correlação.png** reapareceu conforme imagem abaixo:

![correção](https://user-images.githubusercontent.com/35925620/76693752-48e78680-6649-11ea-8e34-2f2a513a9b87.png)

